### PR TITLE
Support for a config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .project
 .pydevproject
 .DS_Store
+
+#Configuration
+plugin.image.xbmctumblrslideshow/config.txt

--- a/plugin.image.xbmctumblrslideshow/default.py
+++ b/plugin.image.xbmctumblrslideshow/default.py
@@ -2,7 +2,7 @@
 import sys
 import urllib2
 import json
-
+import ConfigParser
 import xbmcgui
 import xbmcaddon
 __settings__ = xbmcaddon.Addon(id='script.image.lastfm.slideshow')
@@ -13,7 +13,12 @@ sys.path.append(lib)
 print sys.path
 from xbmcapi import XBMCSourcePlugin
 
-API_KEY = 'x1XhpKkt9qCtqyXdDEGHp5TCDQ1TOWm2VTLiWUm0FHpdkHI5Rj'
+config = ConfigParser.ConfigParser()
+config.read('~/.xbmc-tumblr_config')
+
+
+API_KEY = config.get('API','key')
+
 
 def getText(nodelist):
     rc = []
@@ -26,7 +31,8 @@ def getText(nodelist):
 plugin = XBMCSourcePlugin()
 
 def catagories():
-	cats = [c.strip() for c in plugin.getSetting('tumblrs').split()]
+#	cats = [c.strip() for c in plugin.getSetting('tumblrs').split()]
+	cats = config.get('blogs','blog_name').split(',')
 	for cat in cats:
 		thumbnail = 'http://api.tumblr.com/v2/blog/%s.tumblr.com/avatar/256' % cat
 		listitem = xbmcgui.ListItem(cat, iconImage=thumbnail)

--- a/plugin.image.xbmctumblrslideshow/default.py
+++ b/plugin.image.xbmctumblrslideshow/default.py
@@ -5,6 +5,7 @@ import json
 import ConfigParser
 import xbmcgui
 import xbmcaddon
+import os
 __settings__ = xbmcaddon.Addon(id='script.image.lastfm.slideshow')
 __language__ = __settings__.getLocalizedString
 lib = os.path.join(__settings__.getAddonInfo('path'), 'Resources', 'lib')
@@ -16,9 +17,12 @@ from xbmcapi import XBMCSourcePlugin
 config = ConfigParser.ConfigParser()
 config.read('~/.xbmc-tumblr_config')
 
-
-API_KEY = config.get('API','key')
-
+#Use old API key if one is not found
+try:
+	API_KEY = config.get('API','key')
+except (ConfigParser.NoSectionError ,ConfigParser.NoOptionError) as e:
+	API_KEY = 'x1XhpKkt9qCtqyXdDEGHp5TCDQ1TOWm2VTLiWUm0FHpdkHI5Rj'
+	pass
 
 def getText(nodelist):
     rc = []
@@ -30,9 +34,14 @@ def getText(nodelist):
 
 plugin = XBMCSourcePlugin()
 
-def catagories():
-#	cats = [c.strip() for c in plugin.getSetting('tumblrs').split()]
-	cats = config.get('blogs','blog_name').split(',')
+def catagories():	
+#Use settings from menu if nothing is found in the config file
+	try:	
+		cats = config.get('blogs','blog_name').split(',')
+	except (ConfigParser.NoSectionError ,ConfigParser.NoOptionError) as e:
+		cats = [c.strip() for c in plugin.getSetting('tumblrs').split()]
+		pass
+
 	for cat in cats:
 		thumbnail = 'http://api.tumblr.com/v2/blog/%s.tumblr.com/avatar/256' % cat
 		listitem = xbmcgui.ListItem(cat, iconImage=thumbnail)

--- a/plugin.image.xbmctumblrslideshow/default.py
+++ b/plugin.image.xbmctumblrslideshow/default.py
@@ -15,7 +15,7 @@ print sys.path
 from xbmcapi import XBMCSourcePlugin
 
 config = ConfigParser.ConfigParser()
-config.read('~/.xbmc-tumblr_config')
+config.read(os.path.join(__settings__.getAddonInfo('path'),'config.txt'))
 
 #Use old API key if one is not found
 try:

--- a/plugin.image.xbmctumblrslideshow/xbmcapi
+++ b/plugin.image.xbmctumblrslideshow/xbmcapi
@@ -1,1 +1,0 @@
-/Users/mpetersen/Documents/AptanaWorkspace/xbmc-dev/xbmcapi/xbmcapi

--- a/plugin.image.xbmctumblrslideshow/xbmcapi/__init__.py
+++ b/plugin.image.xbmctumblrslideshow/xbmcapi/__init__.py
@@ -1,0 +1,40 @@
+import os
+import re
+import sys
+
+
+import xbmc
+import xbmcgui
+import xbmcaddon
+import xbmcplugin
+
+class XBMCAddon(object):
+	def __init__(self, name):
+		self.name = name
+		self.settings = xbmcaddon.Addon(id=name)
+		self.anguage = self.settings.getLocalizedString
+		self.home = self.settings.getAddonInfo('path')
+		self.icon = xbmc.translatePath( os.path.join( self.home, 'icon.png' ) )
+
+class XBMCSourcePlugin(XBMCAddon):
+	def __init__(self):
+		self.root = re.match(r'plugin:\/\/[A-Za-z0-9_.-]+', sys.argv[0]).group(0)
+		XBMCAddon.__init__(self, self.root[8:])
+		self.path = sys.argv[0].replace(self.root,'').lstrip('/').split('?')[0]
+		self.query = {}
+		if '?' in sys.argv[2]:
+			query = sys.argv[2][1:].split('&')
+			for q in query:
+				k, v = q.split('=')
+				self.query[k] = v
+		self.id = int(sys.argv[1])
+
+	def getSetting(self, setting):
+		return xbmcplugin.getSetting(self.id, setting)
+
+	def endOfDirectory(self):
+		xbmcplugin.endOfDirectory(self.id)
+
+	def addDirectoryItem(self, url, listitem=None, isFolder=False):
+		return xbmcplugin.addDirectoryItem(handle=self.id, url=url, listitem=listitem, isFolder=isFolder)
+


### PR DESCRIPTION
I was using this on the raspbmc and since I don't have a keyboard plugged in, it was just really hard to type out the names of the blogs with my TV remote. I've added support for a config file, so I can type the names on my computer and then scp the config file over to the Pi.

Thanks for the plugin!
